### PR TITLE
Use constant time comparison in user_check_password.

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,18 @@ function user_check_password(password, hashedPassword) {
     default:
       return false;
   }
-  return (hashed && stored_hash == hashed);
+
+  // Use a constant time comparison to prevent timing attacks.
+  if (hashed) {
+    var mismatch = 0;
+    for (var i = 0, l = hashed.length; i < l; ++i) {
+      mismatch |= (hashed.charCodeAt(i) ^ stored_hash.charCodeAt(i));
+    }
+    return mismatch === 0;
+  }
+  else {
+    return false;
+  }
 }
 
 function user_needs_new_hash(hashedPassword) {


### PR DESCRIPTION
This PR adds a constant time string comparison of `hashed` and `stored_hash` in the `user_check_password` function. See the following for details:

https://snyk.io/blog/node-js-timing-attack-ccc-ctf/

**EDIT**

Love this module. Saved me the effort of implementing the Drupal hashing myself, so thank you! Not sure if this type of timing attack applies, but it was a simple PR.